### PR TITLE
 Fix error message to suggest [UITestMethod] only for UWP Projects (#…

### DIFF
--- a/src/Adapter/MSTest.CoreAdapter/Resources/Resource.Designer.cs
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/Resource.Designer.cs
@@ -641,7 +641,7 @@ namespace Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread..
+        ///   Looks up a localized string similar to {0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread..
         /// </summary>
         internal static string UTA_WrongThread {
             get {

--- a/src/Adapter/MSTest.CoreAdapter/Resources/Resource.resx
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/Resource.resx
@@ -264,7 +264,7 @@ Error: {1}</value>
 {2}</value>
   </data>
   <data name="UTA_WrongThread" xml:space="preserve">
-    <value>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</value>
+    <value>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</value>
   </data>
   <data name="AttachmentSetDisplayName" xml:space="preserve">
     <value>MSTestAdapterV2</value>

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.cs.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.cs.xlf
@@ -246,8 +246,8 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_WrongThread">
-        <source>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
-        <target state="translated">{0}. Pokud v testu používáte objekty uživatelského rozhraní, zvažte použití atributu [UITestMethod] namísto atributu [TestMethod], aby se test provedl ve vlákně uživatelského rozhraní.</target>
+        <source>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
+        <target state="new">{0}. Pokud v testu používáte objekty uživatelského rozhraní, zvažte použití atributu [UITestMethod] namísto atributu [TestMethod], aby se test provedl ve vlákně uživatelského rozhraní.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="AttachmentSetDisplayName">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.de.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.de.xlf
@@ -246,8 +246,8 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_WrongThread">
-        <source>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
-        <target state="translated">{0}. Wenn Sie UI-Objekte im Test verwenden, sollten Sie ggf. das [UITestMethod]-Attribut anstelle von "[TestMethod]" verwenden, um den Test im UI-Thread auszuführen.</target>
+        <source>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
+        <target state="new">{0}. Wenn Sie UI-Objekte im Test verwenden, sollten Sie ggf. das [UITestMethod]-Attribut anstelle von "[TestMethod]" verwenden, um den Test im UI-Thread auszuführen.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="AttachmentSetDisplayName">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.es.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.es.xlf
@@ -246,8 +246,8 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_WrongThread">
-        <source>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
-        <target state="translated">{0}. Si usa objetos de interfaz de usuario en la prueba, podría usar el atributo [UITestMethod] en lugar de [TestMethod] para ejecutar la prueba en el subproceso de interfaz de usuario.</target>
+        <source>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
+        <target state="new">{0}. Si usa objetos de interfaz de usuario en la prueba, podría usar el atributo [UITestMethod] en lugar de [TestMethod] para ejecutar la prueba en el subproceso de interfaz de usuario.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="AttachmentSetDisplayName">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.fr.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.fr.xlf
@@ -246,8 +246,8 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_WrongThread">
-        <source>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
-        <target state="translated">{0}. Si vous utilisez des objets d'interface utilisateur dans un test, vous pouvez utiliser l'attribut [UITestMethod] au lieu de [TestMethod] pour exécuter le test dans le thread d'interface utilisateur.</target>
+        <source>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
+        <target state="new">{0}. Si vous utilisez des objets d'interface utilisateur dans un test, vous pouvez utiliser l'attribut [UITestMethod] au lieu de [TestMethod] pour exécuter le test dans le thread d'interface utilisateur.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="AttachmentSetDisplayName">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.it.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.it.xlf
@@ -246,8 +246,8 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_WrongThread">
-        <source>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
-        <target state="translated">{0}. Se si usano oggetti dell'interfaccia utente nel test, provare a specificare l'attributo [UITestMethod] invece di [TestMethod] per eseguire il test nel thread dell'interfaccia utente.</target>
+        <source>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
+        <target state="new">{0}. Se si usano oggetti dell'interfaccia utente nel test, provare a specificare l'attributo [UITestMethod] invece di [TestMethod] per eseguire il test nel thread dell'interfaccia utente.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="AttachmentSetDisplayName">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ja.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ja.xlf
@@ -246,8 +246,8 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_WrongThread">
-        <source>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
-        <target state="translated">{0}。テスト内で UI オブジェクトを使用している場合は、[TestMethod] の代わりに [UITestMethod] 属性を使用して UI スレッド内でテストを実行することを検討してください。</target>
+        <source>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
+        <target state="new">{0}。テスト内で UI オブジェクトを使用している場合は、[TestMethod] の代わりに [UITestMethod] 属性を使用して UI スレッド内でテストを実行することを検討してください。</target>
         <note></note>
       </trans-unit>
       <trans-unit id="AttachmentSetDisplayName">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ko.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ko.xlf
@@ -246,8 +246,8 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_WrongThread">
-        <source>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
-        <target state="translated">{0}. 테스트에서 UI 개체를 사용 중인 경우 [TestMethod] 대신 [UITestMethod] 특성을 사용하여 UI 스레드에서 테스트를 실행하세요.</target>
+        <source>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
+        <target state="new">{0}. 테스트에서 UI 개체를 사용 중인 경우 [TestMethod] 대신 [UITestMethod] 특성을 사용하여 UI 스레드에서 테스트를 실행하세요.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="AttachmentSetDisplayName">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pl.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pl.xlf
@@ -246,8 +246,8 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_WrongThread">
-        <source>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
-        <target state="translated">{0}. Jeżeli korzystasz z obiektów interfejsu użytkownika podczas testu, rozważ użycie atrybutu [UITestMethod] zamiast [TestMethod], aby wykonać test w wątku interfejsu użytkownika.</target>
+        <source>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
+        <target state="new">{0}. Jeżeli korzystasz z obiektów interfejsu użytkownika podczas testu, rozważ użycie atrybutu [UITestMethod] zamiast [TestMethod], aby wykonać test w wątku interfejsu użytkownika.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="AttachmentSetDisplayName">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pt-BR.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.pt-BR.xlf
@@ -246,8 +246,8 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_WrongThread">
-        <source>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
-        <target state="translated">{0}. Se você está usando objetos de Interface do Usuário no teste, considere usar o atributo [UITestMethod] em vez do [TestMethod] para executar o teste no thread de Interface do Usuário.</target>
+        <source>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
+        <target state="new">{0}. Se você está usando objetos de Interface do Usuário no teste, considere usar o atributo [UITestMethod] em vez do [TestMethod] para executar o teste no thread de Interface do Usuário.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="AttachmentSetDisplayName">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ru.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.ru.xlf
@@ -246,8 +246,8 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_WrongThread">
-        <source>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
-        <target state="translated">{0}. Если в тесте используются объекты пользовательского интерфейса, рассмотрите возможность использования атрибута [UITestMethod] вместо атрибута [TestMethod] для выполнения теста в потоке пользовательского интерфейса.</target>
+        <source>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
+        <target state="new">{0}. Если в тесте используются объекты пользовательского интерфейса, рассмотрите возможность использования атрибута [UITestMethod] вместо атрибута [TestMethod] для выполнения теста в потоке пользовательского интерфейса.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="AttachmentSetDisplayName">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.tr.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.tr.xlf
@@ -246,8 +246,8 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_WrongThread">
-        <source>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
-        <target state="translated">{0}. Teste UI nesneleri kullanıyorsanız, testi UI iş parçacığında yürütmek için [TestMethod] yerine [UITestMethod] özniteliğini kullanmayı deneyin.</target>
+        <source>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
+        <target state="new">{0}. Teste UI nesneleri kullanıyorsanız, testi UI iş parçacığında yürütmek için [TestMethod] yerine [UITestMethod] özniteliğini kullanmayı deneyin.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="AttachmentSetDisplayName">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.xlf
@@ -246,8 +246,8 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_WrongThread">
-        <source>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
-        <target state="translated">{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</target>
+        <source>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
+        <target state="new">{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</target>
         <note></note>
       </trans-unit>
       <trans-unit id="AttachmentSetDisplayName">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hans.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hans.xlf
@@ -246,8 +246,8 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_WrongThread">
-        <source>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
-        <target state="translated">{0}。如果在测试中使用 UI 对象，请考虑使用 [UITestMethod] 特性代替 [TestMethod] 特性来在 UI 线程中执行测试。</target>
+        <source>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
+        <target state="new">{0}。如果在测试中使用 UI 对象，请考虑使用 [UITestMethod] 特性代替 [TestMethod] 特性来在 UI 线程中执行测试。</target>
         <note></note>
       </trans-unit>
       <trans-unit id="AttachmentSetDisplayName">

--- a/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hant.xlf
+++ b/src/Adapter/MSTest.CoreAdapter/Resources/xlf/Resource.zh-Hant.xlf
@@ -246,8 +246,8 @@ Error: {1}</source>
         <note></note>
       </trans-unit>
       <trans-unit id="UTA_WrongThread">
-        <source>{0}. If you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
-        <target state="translated">{0}。如果您在測試中使用 UI 物件，請考慮使用 [UITestMethod] 屬性取代 [TestMethod] 在 UI 執行緒中執行測試。</target>
+        <source>{0} For UWP projects, if you are using UI objects in test consider using [UITestMethod] attribute instead of [TestMethod] to execute test in UI thread.</source>
+        <target state="new">{0}。如果您在測試中使用 UI 物件，請考慮使用 [UITestMethod] 屬性取代 [TestMethod] 在 UI 執行緒中執行測試。</target>
         <note></note>
       </trans-unit>
       <trans-unit id="AttachmentSetDisplayName">


### PR DESCRIPTION
…615)

* Correcting error message when dynamic data doen't have any data

* Fix error message to suggest [UITestMethod] only for UWP Projects